### PR TITLE
feat: add rabbitmq full connection string to kubernetes secret

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -10,7 +10,8 @@ resource "kubernetes_secret" "secret" {
   }
 
   data = {
-    RABBITMQ_USER     = var.name
-    RABBITMQ_PASSWORD = random_password.password.result
+    RABBITMQ_USER              = var.name
+    RABBITMQ_PASSWORD          = random_password.password.result
+    RABBITMQ_CONNECTION_STRING = var.rabbitmq_protocol + "://" + var.name + ":" + var.password + "@" + var.kubernetes.rabbitmq_host + ":" + var.rabbitmq_port
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,11 +18,17 @@ variable "permissions" {
 
 variable "kubernetes_secret" {
   type = object({
-    enabled   = bool
-    namespace = string
+    enabled           = bool
+    namespace         = string
+    rabbitmq_protocol = string
+    rabbitmq_host     = string
+    rabbitmq_port     = string
   })
   default = {
-    enabled   = false
-    namespace = "default"
+    enabled           = false
+    namespace         = "default"
+    rabbitmq_protocol = "amqp"
+    rabbitmq_host     = "localhost"
+    rabbitmq_port     = "5672"
   }
 }


### PR DESCRIPTION
I need to read this secret from keda, and keda needs the whole connection string